### PR TITLE
Explicitly import file from oauth2client

### DIFF
--- a/deleter.py
+++ b/deleter.py
@@ -9,6 +9,7 @@ from apiclient import discovery
 from apiclient import errors
 import oauth2client
 from oauth2client import client
+from oauth2client import file
 from oauth2client import tools
 
 try:


### PR DESCRIPTION
I'm.. not sure why this apparently worked in some versions/environments but doesn't for me, but explicitly importing it fixes the problem and should be harmless, so..